### PR TITLE
Fix microseconds insertion for timestamptz values

### DIFF
--- a/src/UTCDateTimeImmutableType.php
+++ b/src/UTCDateTimeImmutableType.php
@@ -14,6 +14,8 @@ use Throwable;
 
 use function is_string;
 use function str_contains;
+use function strrpos;
+use function substr_replace;
 
 final class UTCDateTimeImmutableType extends DateTimeImmutableType
 {
@@ -51,7 +53,14 @@ final class UTCDateTimeImmutableType extends DateTimeImmutableType
         $format = $platform->getDateTimeFormatString();
 
         if ($format === 'Y-m-d H:i:s.u' && ! str_contains($value, '.')) {
-            $value .= '.0';
+            $tzPos = strrpos($value, '+');
+            if ($tzPos === false) {
+                $tzPos = strrpos($value, '-', -1);
+            }
+
+            $value = $tzPos !== false && $tzPos > 10
+                ? substr_replace($value, '.0', $tzPos, 0)
+                : $value . '.0';
         }
 
         $dateTime = DateTimeImmutable::createFromFormat($platform->getDateTimeFormatString(), $value);

--- a/src/UTCDateTimeType.php
+++ b/src/UTCDateTimeType.php
@@ -14,6 +14,8 @@ use Throwable;
 
 use function is_string;
 use function str_contains;
+use function strrpos;
+use function substr_replace;
 
 final class UTCDateTimeType extends DateTimeType
 {
@@ -47,7 +49,14 @@ final class UTCDateTimeType extends DateTimeType
         $format = $platform->getDateTimeFormatString();
 
         if ($format === 'Y-m-d H:i:s.u' && ! str_contains($value, '.')) {
-            $value .= '.0';
+            $tzPos = strrpos($value, '+');
+            if ($tzPos === false) {
+                $tzPos = strrpos($value, '-', -1);
+            }
+
+            $value = $tzPos !== false && $tzPos > 10
+                ? substr_replace($value, '.0', $tzPos, 0)
+                : $value . '.0';
         }
 
         $dateTime = DateTime::createFromFormat($platform->getDateTimeFormatString(), $value);

--- a/tests/DateTimeTypeTestCaseBase.php
+++ b/tests/DateTimeTypeTestCaseBase.php
@@ -127,5 +127,8 @@ abstract class DateTimeTypeTestCaseBase extends TestCase
         yield 'timestamp(0)' => [new DateTimeImmutable('2021-12-01 12:34:56.0'), '2021-12-01 12:34:56'];
         yield 'timestamp(3)' => [new DateTimeImmutable('2021-12-01 12:34:56.123'), '2021-12-01 12:34:56.123'];
         yield 'timestamp(6)' => [new DateTimeImmutable('2021-12-01 12:34:56.123456'), '2021-12-01 12:34:56.123456'];
+        yield 'timestamptz(0)' => [new DateTimeImmutable('2021-12-01 12:34:56.0+00'), '2021-12-01 12:34:56+00'];
+        yield 'timestamptz(6)' => [new DateTimeImmutable('2021-12-01 12:34:56.123456+00'), '2021-12-01 12:34:56.123456+00'];
+        yield 'timestamptz(0) negative offset' => [new DateTimeImmutable('2021-12-01 12:34:56.0-05'), '2021-12-01 12:34:56-05'];
     }
 }


### PR DESCRIPTION
## Summary
- When the platform datetime format requires microseconds (`Y-m-d H:i:s.u`) and a value like `2026-03-29 11:32:37+00` has no fractional seconds, `.0` was appended after the timezone offset producing `2026-03-29 11:32:37+00.0` — which is unparseable
- Now `.0` is inserted before the `+`/`-` timezone offset: `2026-03-29 11:32:37.0+00`
- Uses `strrpos` + `substr_replace` for best performance (no regex)