### PR TITLE
Disable Composer lock file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true,
             "phpstan/extension-installer": true
-        }
+        },
+        "lock": false
     },
     "require": {
         "php": "^8.4",

--- a/composer.json
+++ b/composer.json
@@ -10,12 +10,12 @@
         }
     ],
     "config": {
-        "sort-packages": true,
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true,
             "phpstan/extension-installer": true
         },
-        "lock": false
+        "lock": false,
+        "sort-packages": true
     },
     "require": {
         "php": "^8.4",


### PR DESCRIPTION
## Summary
- Disable Composer lock file generation for this library by setting `config.lock` to `false`.
- Keeps dependency resolution flexible for consumers while preserving normal Composer metadata.