### PR TITLE
fix: Correctly interpret database value timezone as UTC if the defau…

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,1 +1,0 @@
-parameters:

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,1 +1,8 @@
 parameters:
+	ignoreErrors:
+		-
+			message: '#^Method SimPod\\DoctrineUtcDateTime\\Tests\\DateTimeTypeTestCaseBase\:\:platform\(\) should return Doctrine\\DBAL\\Platforms\\AbstractPlatform but returns Doctrine\\DBAL\\Platforms\\PostgreSQL100Platform@anonymous/tests/DateTimeTypeTestCaseBase\.php\:37\.$#'
+			identifier: return.type
+			count: 1
+			path: tests/DateTimeTypeTestCaseBase.php
+

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,7 +1,1 @@
 parameters:
-	ignoreErrors:
-		-
-			message: '#^Method SimPod\\DoctrineUtcDateTime\\Tests\\DateTimeTypeTestCaseBase\:\:platform\(\) should return Doctrine\\DBAL\\Platforms\\AbstractPlatform but returns Doctrine\\DBAL\\Platforms\\PostgreSQL100Platform@anonymous/tests/DateTimeTypeTestCaseBase\.php\:28\|Doctrine\\DBAL\\Platforms\\PostgreSQLPlatform@anonymous/tests/DateTimeTypeTestCaseBase\.php\:34\.$#'
-			identifier: return.type
-			count: 1
-			path: tests/DateTimeTypeTestCaseBase.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,8 +1,1 @@
 parameters:
-	ignoreErrors:
-		-
-			message: '#^Method SimPod\\DoctrineUtcDateTime\\Tests\\DateTimeTypeTestCaseBase\:\:platform\(\) should return Doctrine\\DBAL\\Platforms\\AbstractPlatform but returns Doctrine\\DBAL\\Platforms\\PostgreSQL100Platform@anonymous/tests/DateTimeTypeTestCaseBase\.php\:37\.$#'
-			identifier: return.type
-			count: 1
-			path: tests/DateTimeTypeTestCaseBase.php
-

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -3,6 +3,3 @@ parameters:
     paths:
         - %currentWorkingDirectory%/src
         - %currentWorkingDirectory%/tests
-
-includes:
-    - %currentWorkingDirectory%/phpstan-baseline.neon

--- a/src/UTCDateTimeImmutableType.php
+++ b/src/UTCDateTimeImmutableType.php
@@ -54,14 +54,14 @@ final class UTCDateTimeImmutableType extends DateTimeImmutableType
             $value .= '.0';
         }
 
-        $dateTime = DateTimeImmutable::createFromFormat($platform->getDateTimeFormatString(), $value);
+        $dateTime = DateTimeImmutable::createFromFormat($platform->getDateTimeFormatString(), $value, self::utc());
 
         if ($dateTime !== false) {
             return $dateTime;
         }
 
         try {
-            return new DateTimeImmutable($value);
+            return new DateTimeImmutable($value, self::utc());
         } catch (Throwable $e) {
             throw InvalidFormat::new(
                 $value,

--- a/src/UTCDateTimeType.php
+++ b/src/UTCDateTimeType.php
@@ -50,14 +50,14 @@ final class UTCDateTimeType extends DateTimeType
             $value .= '.0';
         }
 
-        $dateTime = DateTime::createFromFormat($platform->getDateTimeFormatString(), $value);
+        $dateTime = DateTime::createFromFormat($platform->getDateTimeFormatString(), $value, self::utc());
 
         if ($dateTime !== false) {
             return $dateTime;
         }
 
         try {
-            return new DateTime($value);
+            return new DateTime($value, self::utc());
         } catch (Throwable $e) {
             throw InvalidFormat::new(
                 $value,

--- a/tests/DateTimeTypeTestCaseBase.php
+++ b/tests/DateTimeTypeTestCaseBase.php
@@ -27,6 +27,7 @@ abstract class DateTimeTypeTestCaseBase extends TestCase
     private function platform(): AbstractPlatform
     {
         if (class_exists('Doctrine\DBAL\Platforms\PostgreSQL120Platform')) {
+            // phpcs:ignore SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.ReferenceViaFullyQualifiedName,SlevomatCodingStandard.ControlStructures.JumpStatementsSpacing.IncorrectLinesCountBeforeFirstControlStructure
             return new class extends \Doctrine\DBAL\Platforms\PostgreSQL120Platform {
                 public function getDateTimeFormatString(): string
                 {
@@ -34,6 +35,7 @@ abstract class DateTimeTypeTestCaseBase extends TestCase
                 }
             };
         } elseif (class_exists('Doctrine\DBAL\Platforms\PostgreSQL100Platform')) { // for doctrine/dbal 3.0.0
+            // phpcs:ignore SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.ReferenceViaFullyQualifiedName,SlevomatCodingStandard.ControlStructures.JumpStatementsSpacing.IncorrectLinesCountBeforeFirstControlStructure
             return new class extends \Doctrine\DBAL\Platforms\PostgreSQL100Platform {
                 public function getDateTimeFormatString(): string
                 {

--- a/tests/DateTimeTypeTestCaseBase.php
+++ b/tests/DateTimeTypeTestCaseBase.php
@@ -7,6 +7,7 @@ namespace SimPod\DoctrineUtcDateTime\Tests;
 use DateTime;
 use DateTimeImmutable;
 use DateTimeInterface;
+use DateTimeZone;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\PostgreSQL100Platform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
@@ -19,6 +20,8 @@ use PHPUnit\Framework\TestCase;
 use SimPod\DoctrineUtcDateTime\UTCDateTimeType;
 
 use function class_exists;
+use function date_default_timezone_get;
+use function date_default_timezone_set;
 
 abstract class DateTimeTypeTestCaseBase extends TestCase
 {
@@ -92,10 +95,13 @@ abstract class DateTimeTypeTestCaseBase extends TestCase
         yield 'DateTime formatted' => [$now, $now->format('Y-m-d H:i:s.u')];
     }
 
-    public function testConvertToPHPValueWithDifferentDefaultTimezone(): void {
+    public function testConvertToPHPValueWithDifferentDefaultTimezone(): void
+    {
+        $type = static::type();
+
         $dbValueUtc = $type instanceof UTCDateTimeType
-            ? new DateTime('2026-06-24T12:08:33.0', new \DateTimeZone('UTC'))
-            : new DateTimeImmutable('2026-06-24T12:08:33.0', new \DateTimeZone('UTC'));
+            ? new DateTime('2026-06-24T12:08:33.0', new DateTimeZone('UTC'))
+            : new DateTimeImmutable('2026-06-24T12:08:33.0', new DateTimeZone('UTC'));
 
         $previousTz = date_default_timezone_get();
         date_default_timezone_set('Europe/Athens');

--- a/tests/DateTimeTypeTestCaseBase.php
+++ b/tests/DateTimeTypeTestCaseBase.php
@@ -35,7 +35,7 @@ abstract class DateTimeTypeTestCaseBase extends TestCase
                 }
             };
         } elseif (class_exists('Doctrine\DBAL\Platforms\PostgreSQL100Platform')) { // for doctrine/dbal 3.0.0
-            // phpcs:ignore SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.ReferenceViaFullyQualifiedName,SlevomatCodingStandard.ControlStructures.JumpStatementsSpacing.IncorrectLinesCountBeforeFirstControlStructure
+            // phpcs:ignore SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.ReferenceViaFullyQualifiedName,SlevomatCodingStandard.ControlStructures.JumpStatementsSpacing.IncorrectLinesCountBeforeFirstControlStructure -- @phpstan-ignore return.type
             return new class extends \Doctrine\DBAL\Platforms\PostgreSQL100Platform {
                 public function getDateTimeFormatString(): string
                 {

--- a/tests/DateTimeTypeTestCaseBase.php
+++ b/tests/DateTimeTypeTestCaseBase.php
@@ -112,8 +112,6 @@ abstract class DateTimeTypeTestCaseBase extends TestCase
             date_default_timezone_set($previousTz);
         }
 
-        self::assertNotNull($phpValue);
-
         self::assertSame(
             $dbValueUtc->format('Y-m-d\TH:i:s.uP'),
             $phpValue->format('Y-m-d\TH:i:s.uP'),

--- a/tests/DateTimeTypeTestCaseBase.php
+++ b/tests/DateTimeTypeTestCaseBase.php
@@ -9,7 +9,6 @@ use DateTimeImmutable;
 use DateTimeInterface;
 use DateTimeZone;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Platforms\PostgreSQL120Platform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Types\DateTimeImmutableType;
 use Doctrine\DBAL\Types\DateTimeType;
@@ -27,19 +26,28 @@ abstract class DateTimeTypeTestCaseBase extends TestCase
 {
     private function platform(): AbstractPlatform
     {
-        return class_exists('Doctrine\DBAL\Platforms\PostgreSQL120Platform')
-            ? new class extends PostgreSQL120Platform {
-                public function getDateTimeFormatString(): string
-                {
-                    return 'Y-m-d H:i:s.u';
-                }
-            }
-            : new class extends PostgreSQLPlatform {
+        if (class_exists('Doctrine\DBAL\Platforms\PostgreSQL120Platform')) {
+            return new class extends \Doctrine\DBAL\Platforms\PostgreSQL120Platform {
                 public function getDateTimeFormatString(): string
                 {
                     return 'Y-m-d H:i:s.u';
                 }
             };
+        } elseif (class_exists('Doctrine\DBAL\Platforms\PostgreSQL100Platform')) { // for doctrine/dbal 3.0.0
+            return new class extends \Doctrine\DBAL\Platforms\PostgreSQL100Platform {
+                public function getDateTimeFormatString(): string
+                {
+                    return 'Y-m-d H:i:s.u';
+                }
+            };
+        } else {
+            return new class extends PostgreSQLPlatform {
+                public function getDateTimeFormatString(): string
+                {
+                    return 'Y-m-d H:i:s.u';
+                }
+            };
+        }
     }
 
     abstract protected static function type(): DateTimeImmutableType|DateTimeType;

--- a/tests/DateTimeTypeTestCaseBase.php
+++ b/tests/DateTimeTypeTestCaseBase.php
@@ -89,6 +89,24 @@ abstract class DateTimeTypeTestCaseBase extends TestCase
         $now = static::type() instanceof UTCDateTimeType ? new DateTime() : new DateTimeImmutable();
 
         yield 'DateTime interface' => [$now, $now];
+        yield 'DateTime formatted' => [$now, $now->format('Y-m-d H:i:s.u')];
+    }
+
+    public function testConvertToPHPValueWithDifferentDefaultTimezone(): void {
+        $type = static::type();
+
+        $dbValueUtc = static::type() instanceof UTCDateTimeType
+            ? new DateTime('2026-06-24T12:08:33.0', new \DateTimeZone('UTC'))
+            : new DateTimeImmutable('2026-06-24T12:08:33.0', new \DateTimeZone('UTC'));
+
+        date_default_timezone_set('Europe/Athens');
+        $phpValue = $type->convertToPHPValue($dbValueUtc->format('Y-m-d H:i:s'), $this->platform());
+        date_default_timezone_set('UTC');
+
+        self::assertSame(
+            $dbValueUtc?->format('Y-m-d\TH:i:s.uP'),
+            $phpValue?->format('Y-m-d\TH:i:s.uP'),
+        );
     }
 
     #[DataProvider('providerConvertToPHPValueFailsWithInvalidType')]

--- a/tests/DateTimeTypeTestCaseBase.php
+++ b/tests/DateTimeTypeTestCaseBase.php
@@ -103,6 +103,13 @@ abstract class DateTimeTypeTestCaseBase extends TestCase
 
         yield 'DateTime interface' => [$now, $now];
         yield 'DateTime formatted' => [$now, $now->format('Y-m-d H:i:s.u')];
+
+        $fallbackValue    = '2026-06-24T12:08:33';
+        $fallbackDateTime = static::type() instanceof UTCDateTimeType
+            ? new DateTime($fallbackValue, new DateTimeZone('UTC'))
+            : new DateTimeImmutable($fallbackValue, new DateTimeZone('UTC'));
+
+        yield 'DateTime constructor formatted' => [$fallbackDateTime, $fallbackValue];
     }
 
     public function testConvertToPHPValueWithDifferentDefaultTimezone(): void

--- a/tests/DateTimeTypeTestCaseBase.php
+++ b/tests/DateTimeTypeTestCaseBase.php
@@ -99,9 +99,14 @@ abstract class DateTimeTypeTestCaseBase extends TestCase
             ? new DateTime('2026-06-24T12:08:33.0', new \DateTimeZone('UTC'))
             : new DateTimeImmutable('2026-06-24T12:08:33.0', new \DateTimeZone('UTC'));
 
+        $previousTz = date_default_timezone_get();
         date_default_timezone_set('Europe/Athens');
-        $phpValue = $type->convertToPHPValue($dbValueUtc->format('Y-m-d H:i:s'), $this->platform());
-        date_default_timezone_set('UTC');
+
+        try {
+            $phpValue = $type->convertToPHPValue($dbValueUtc->format('Y-m-d H:i:s'), $this->platform());
+        } finally {
+            date_default_timezone_set($previousTz);
+        }
 
         self::assertSame(
             $dbValueUtc?->format('Y-m-d\TH:i:s.uP'),

--- a/tests/DateTimeTypeTestCaseBase.php
+++ b/tests/DateTimeTypeTestCaseBase.php
@@ -9,7 +9,7 @@ use DateTimeImmutable;
 use DateTimeInterface;
 use DateTimeZone;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Platforms\PostgreSQL100Platform;
+use Doctrine\DBAL\Platforms\PostgreSQL120Platform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Types\DateTimeImmutableType;
 use Doctrine\DBAL\Types\DateTimeType;
@@ -27,8 +27,8 @@ abstract class DateTimeTypeTestCaseBase extends TestCase
 {
     private function platform(): AbstractPlatform
     {
-        return class_exists('Doctrine\DBAL\Platforms\PostgreSQL100Platform')
-            ? new class extends PostgreSQL100Platform {
+        return class_exists('Doctrine\DBAL\Platforms\PostgreSQL120Platform')
+            ? new class extends PostgreSQL120Platform {
                 public function getDateTimeFormatString(): string
                 {
                     return 'Y-m-d H:i:s.u';

--- a/tests/DateTimeTypeTestCaseBase.php
+++ b/tests/DateTimeTypeTestCaseBase.php
@@ -93,9 +93,7 @@ abstract class DateTimeTypeTestCaseBase extends TestCase
     }
 
     public function testConvertToPHPValueWithDifferentDefaultTimezone(): void {
-        $type = static::type();
-
-        $dbValueUtc = static::type() instanceof UTCDateTimeType
+        $dbValueUtc = $type instanceof UTCDateTimeType
             ? new DateTime('2026-06-24T12:08:33.0', new \DateTimeZone('UTC'))
             : new DateTimeImmutable('2026-06-24T12:08:33.0', new \DateTimeZone('UTC'));
 
@@ -108,9 +106,11 @@ abstract class DateTimeTypeTestCaseBase extends TestCase
             date_default_timezone_set($previousTz);
         }
 
+        self::assertNotNull($phpValue);
+
         self::assertSame(
-            $dbValueUtc?->format('Y-m-d\TH:i:s.uP'),
-            $phpValue?->format('Y-m-d\TH:i:s.uP'),
+            $dbValueUtc->format('Y-m-d\TH:i:s.uP'),
+            $phpValue->format('Y-m-d\TH:i:s.uP'),
         );
     }
 


### PR DESCRIPTION
…lt timezone is different (#86)

This makes the code interpret the database value as being in UTC timezone even if the default timezone configured in PHP is different.
This brings back the behavior of v0.2.1. It might be a backwards compatibility break for people using v0.3.1 so I suggest a version bump to v0.4.0.

Closes #86 