### PR TITLE
Ignore PHPUnit cache directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /.phpcs-cache
 /phpstan.neon
 .phpunit.result.cache
+/.phpunit.cache/


### PR DESCRIPTION
Adds the PHPUnit cache directory generated by recent PHPUnit runs to .gitignore.